### PR TITLE
Inject header and footer directly at the correct position

### DIFF
--- a/extension.json
+++ b/extension.json
@@ -20,7 +20,8 @@
 		}
 	},
 	"Hooks": {
-		"BeforePageDisplay": "MediaWiki\\Extension\\FsHeader\\Hooks::onBeforePageDisplay"
+		"BeforePageDisplay": "MediaWiki\\Extension\\FsHeader\\Hooks::onBeforePageDisplay",
+		"SkinTemplateOutputPageBeforeExec": "MediaWiki\\Extension\\FsHeader\\Hooks::onSkinTemplateOutputPageBeforeExec"
 	},
 	"MessagesDirs": {
 		"FsHeader": [
@@ -32,10 +33,18 @@
 		"remoteExtPath": "FsHeader/resources"
 	},
 	"ResourceModules": {
-		"ext.FsHeader": {
+		"z.ext.FsHeader.styles": {
 			"dependencies": [],
 			"messages": [],
+			"position": "top",
 			"styles": ["header.css", "footer.css", "common.css"],
+			"scripts": [],
+			"targets": ["desktop", "mobile"]
+		},
+		"ext.FsHeader.scripts": {
+			"dependencies": [],
+			"messages": [],
+			"styles": [],
 			"scripts": ["script.js", "jQuery-rwdImageMaps/jquery.rwdImageMaps.js"],
 			"targets": ["desktop", "mobile"]
 		}

--- a/includes/Hooks.php
+++ b/includes/Hooks.php
@@ -20,7 +20,9 @@
 namespace MediaWiki\Extension\FsHeader;
 
 use OutputPage;
+use QuickTemplate;
 use Skin;
+use SkinTemplate;
 
 class Hooks {
 
@@ -30,29 +32,10 @@ class Hooks {
 	 * @param Skin $skin Skin object that will be used to generate the page
 	 */
 	public static function onBeforePageDisplay( OutputPage $out, Skin $skin ) {
-		$out->addModules ("ext.FsHeader");
+		$out->addModuleStyles( "z.ext.FsHeader.styles" );
+		$out->addModules ("ext.FsHeader.scripts");
 
 		global $wgUser;
-
-		$t = function ( $key ) use ( $out ) {
-			echo $out->msg( $key )->inContentLanguage()->escaped();
-		};
-
-		ob_start();
-		require "footer.php";
-		$html = ob_get_contents();
-		ob_end_clean();
-		$out->addHTML($html);
-
-		ob_start();
-		require "header.php";
-		$html = ob_get_contents();
-		// get rid of the output buffer so it isn't flushed automatically
-		ob_end_clean();
-		// output the header at the end of the content
-		// we fix it up with javascript
-		$out->addHtml($html);
-
 
 		// modify the login links
 		if ( $wgUser->isLoggedIn() ) {
@@ -63,4 +46,31 @@ class Hooks {
 		return true;
 	}
 
+	public static function onSkinTemplateOutputPageBeforeExec( SkinTemplate &$skinTemplate, QuickTemplate &$tpl ){
+
+		global $wgUser;
+
+		$out = $tpl->getSkin()->getOutput();
+
+		$t = function ( $key ) use ( $out ) {
+			echo $out->msg( $key )->inContentLanguage()->escaped();
+		};
+
+		ob_start();
+		require "footer.php";
+		$html = ob_get_contents();
+		ob_end_clean();
+
+		$tpl->set( 'bottomscripts', $tpl->get( 'bottomscripts' ) . $html );
+
+		ob_start();
+		require "header.php";
+		$html = ob_get_contents();
+		// get rid of the output buffer so it isn't flushed automatically
+		ob_end_clean();
+
+		$tpl->set( 'headelement', $tpl->get( 'headelement' ) . $html );
+
+		return true;
+	}
 }

--- a/includes/footer.php
+++ b/includes/footer.php
@@ -1,6 +1,6 @@
 
 <!-- Create the menu items in the appropriate language for the footer : "About   Blog   Site Map    Solutions Gallery   Cookie Preferences"-->
-<div id="fs-footer" style="width:100%; z-index:2; left:-0.25rem; padding-bottom:1.5rem;">
+<div id="fs-footer">
 	<!-- when > = 992px -->
 	<div class="footer-container">
 		<div class="footer-nav">

--- a/resources/footer.css
+++ b/resources/footer.css
@@ -108,6 +108,16 @@
 	}
 */
 	@media screen and (max-width: 991px) {
+
+		body #fs-footer {
+			padding: 1.5rem 0;
+			margin: 0 10%;
+		}
+
+		body #mw-mf-viewport {
+			height: auto;
+		}
+
 		body #fs-footer .footer-container span.church-logo-container {
 			text-align:center;
 		}
@@ -118,5 +128,11 @@
 			position:relative;
 			bottom:80px;
 			}
+
+		body #fs-footer {
+			margin-left: 11em;
+			padding: 0 1.25em 1.5em 1.25em;
+		}
+
 	}
-}  	/* end media all */
+  	/* end media all */

--- a/resources/header.css
+++ b/resources/header.css
@@ -464,6 +464,7 @@ body {
 
    @media screen and (min-width: 992px){
 	   body header#main-header{
+		   position: absolute;
 		   height:77px!important;
 	   }
    }

--- a/resources/script.js
+++ b/resources/script.js
@@ -3,44 +3,6 @@ $(document).ready(function(e) {
 	// responsive image maps
 	$('img[usemap]').rwdImageMaps();
 
-
-
-	// move the main-header to the top of the page
-	var h = document.getElementById('main-header');
-	// move the footer to the bottom of the page
-	var ff = document.getElementById('fs-footer');
-	var f = document.getElementById('footer');
-	if (f && ff) {
-		f.appendChild(ff);
-	}
-
-	// desktop insertion point
-	var a = document.getElementById('mw-page-base');
-	var isMobile = false;
-	var isApi = false;
-	if ( a == null ) {
-		// mobile insertion point
-		a = document.getElementById('mw-mf-viewport');
-		isMobile = true;
-		if ( a == null ) {
-			isMobile = false;
-			isApi = true;
-		}
-	}
-	if ( isApi ) {
-		var body = document.querySelector('body');
-		body.insertBefore(h, body.firstChild);
-	} else {
-		a.insertBefore(h, a.firstChild);
-	}
-
-	// change the footer layout for mobile
-    if ( isMobile ) {
-		$('#fs-footer').css({"width":"80%", "left":"1.25rem", "padding-bottom":"1.5rem"});
-
-	}
-
-
 	var mobile_menus = $(".mobile_nav .menu-item-has-children .sub-menu").hide();
 
 	//on page resize re-calculate the left padding on the nav menu


### PR DESCRIPTION
* Use SkinTemplateOutputPageBeforeExec hook to inject header and footer
* The actual position changed slightly from somewhere inside the page body to directly after the opening <body> tag for the header and directly before the closing </body> tag for the footer.
* CSS has been adapted for the change in position.
* JS code that is not needed anymore has been removed.
* The module definition has been split into styles and scripts parts to allow for earlier loading of styles to avoid jumping page elements.